### PR TITLE
Fix: unknown field "terminationGracePeriodSeconds"

### DIFF
--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -25,4 +25,4 @@ spec:
           requests:
             cpu: 100m
             memory: 50Mi
-  terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 10


### PR DESCRIPTION
I found an error in apply. I fixed it.

```
error: error validating "STDIN": error validating data: ValidationError(Deployment.spec): unknown field "terminationGracePeriodSeconds" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false
```