### PR TITLE
Fix: image pull backoff

### DIFF
--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -15,7 +15,6 @@ spec:
     spec:
       serviceAccountName: originissuer-control
       containers:
-        # pushing to Docker Hub will be available after open sourcing
       - image: cloudflare/origin-ca-issuer:v0.5.0
         name: origin-ca-controller
         resources:

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: originissuer-control
       containers:
         # pushing to Docker Hub will be available after open sourcing
-      - image: origin-ca-issuer:latest
+      - image: cloudflare/origin-ca-issuer:v0.5.0
         name: origin-ca-controller
         resources:
           limits:


### PR DESCRIPTION
An error occurs because the image specified in manifest does not exist. Also, since latest does not exist, I fixed the tag.