### PR TITLE
fix(docker): include certificate store

### DIFF
--- a/hack/docker.nix
+++ b/hack/docker.nix
@@ -6,5 +6,8 @@ let controller = callPackage ./derivation.nix { };
 
 in dockerTools.buildLayeredImage {
   name = "origin-ca-issuer";
-  config.Entrypoint = [ "${controller}/bin/controller" ];
+  config = {
+    Entrypoint = [ "${controller}/bin/controller" ];
+    Env = [ "NIX_SSL_CERT_FILE=${cacert}/etc/ssl/certs/ca-bundle.crt" ];
+  };
 }


### PR DESCRIPTION
Ensure the origin-ca-issuer controller can find CA certificates needed
to verify the Cloudflare API.

Fixes #11