### PR TITLE
chore(crds): update resources to v1

### DIFF
--- a/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml
+++ b/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -12,110 +12,108 @@ spec:
     listKind: OriginIssuerList
     plural: originissuers
     singular: originissuer
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: An OriginIssuer represents the Cloudflare Origin CA as an external
-        cert-manager isuer. It is scoped to a single namespace, so it can be used
-        only by resources in the same namespace.
-      type: object
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: Desired state of the OriginIssuer resource
-          type: object
-          required:
-          - auth
-          - requestType
-          properties:
-            auth:
-              description: Auth configures how to authenticate with the Cloudflare
-                API.
-              type: object
-              properties:
-                serviceKeyRef:
-                  description: ServiceKeyRef authenticates with an API Service Key.
-                  type: object
-                  required:
-                  - key
-                  - name
-                  properties:
-                    key:
-                      description: Key of the secret to select from. Must be a valid
-                        secret key.
-                      type: string
-                    name:
-                      description: Name of the secret in the OriginIssuer's naemspace
-                        to select from.
-                      type: string
-            requestType:
-              description: RequestType is the signature algorithm Cloudflare should
-                use to sign the certificate.
-              type: string
-              enum:
-              - OriginRSA
-              - OriginECC
-        status:
-          description: Status of the OriginIssuer. This is set and managed automatically.
-          type: object
-          properties:
-            conditions:
-              description: List of status conditions to indicate the status of an
-                OriginIssuer Known condition types are `Ready`.
-              type: array
-              items:
-                description: OriginIssuerCondition contains condition information
-                  for the OriginIssuer.
-                type: object
-                required:
-                - status
-                - type
-                properties:
-                  lastTransitionTime:
-                    description: LastTransitioTime is the timestamp corresponding
-                      to the last status change of this condition.
-                    type: string
-                    format: date-time
-                  message:
-                    description: Message is a human readable description of the details
-                      of the last transition1, complementing reason.
-                    type: string
-                  reason:
-                    description: Reason is a brief machine readable explanation for
-                      the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of ('True', 'False',
-                      'Unknown')
-                    type: string
-                    enum:
-                    - "True"
-                    - "False"
-                    - Unknown
-                  type:
-                    description: Type of the condition, known values are ('Ready')
-                    type: string
-                    enum:
-                    - Ready
-  version: v1
   versions:
   - name: v1
+    schema:
+      openAPIV3Schema:
+        description: An OriginIssuer represents the Cloudflare Origin CA as an external
+          cert-manager issuer. It is scoped to a single namespace, so it can be used
+          only by resources in the same namespace.
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the OriginIssuer resource
+            type: object
+            required:
+            - auth
+            - requestType
+            properties:
+              auth:
+                description: Auth configures how to authenticate with the Cloudflare
+                  API.
+                type: object
+                properties:
+                  serviceKeyRef:
+                    description: ServiceKeyRef authenticates with an API Service Key.
+                    type: object
+                    required:
+                    - key
+                    - name
+                    properties:
+                      key:
+                        description: Key of the secret to select from. Must be a valid
+                          secret key.
+                        type: string
+                      name:
+                        description: Name of the secret in the OriginIssuer's namespace
+                          to select from.
+                        type: string
+              requestType:
+                description: RequestType is the signature algorithm Cloudflare should
+                  use to sign the certificate.
+                type: string
+                enum:
+                - OriginRSA
+                - OriginECC
+          status:
+            description: Status of the OriginIssuer. This is set and managed automatically.
+            type: object
+            properties:
+              conditions:
+                description: List of status conditions to indicate the status of an
+                  OriginIssuer Known condition types are `Ready`.
+                type: array
+                items:
+                  description: OriginIssuerCondition contains condition information
+                    for the OriginIssuer.
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the timestamp corresponding
+                        to the last status change of this condition.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human readable description of the
+                        details of the last transition1, complementing reason.
+                      type: string
+                    reason:
+                      description: Reason is a brief machine readable explanation
+                        for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of ('True', 'False',
+                        'Unknown')
+                      type: string
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                    type:
+                      description: Type of the condition, known values are ('Ready')
+                      type: string
+                      enum:
+                      - Ready
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkgs/apis/v1/types_originissuer.go
+++ b/pkgs/apis/v1/types_originissuer.go
@@ -7,7 +7,7 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:subresource:status
 
-// An OriginIssuer represents the Cloudflare Origin CA as an external cert-manager isuer.
+// An OriginIssuer represents the Cloudflare Origin CA as an external cert-manager issuer.
 // It is scoped to a single namespace, so it can be used only by resources in the same
 // namespace.
 type OriginIssuer struct {
@@ -60,7 +60,7 @@ type OriginIssuerAuthentication struct {
 
 // SecretKeySelector contains a reference to a secret.
 type SecretKeySelector struct {
-	// Name of the secret in the OriginIssuer's naemspace to select from.
+	// Name of the secret in the OriginIssuer's namespace to select from.
 	Name string `json:"name"`
 	// Key of the secret to select from. Must be a valid secret key.
 	Key string `json:"key"`
@@ -74,7 +74,7 @@ type OriginIssuerCondition struct {
 	// Status of the condition, one of ('True', 'False', 'Unknown')
 	Status ConditionStatus `json:"status"`
 
-	// LastTransitioTime is the timestamp corresponding to the last status
+	// LastTransitionTime is the timestamp corresponding to the last status
 	// change of this condition.
 	// +optional
 	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
@@ -99,7 +99,7 @@ const (
 	// RequestTypeOriginRSA represents an RSA256 signature.
 	RequestTypeOriginRSA RequestType = "OriginRSA"
 
-	// RequestTypeOriginECC respresnts an ECDSA signature.
+	// RequestTypeOriginECC represents an ECDSA signature.
 	RequestTypeOriginECC RequestType = "OriginECC"
 )
 

--- a/shell.nix
+++ b/shell.nix
@@ -24,13 +24,13 @@ let
   };
   controller-tools = buildGoModule rec {
     pname = "controller-tools";
-    version = "0.4.0";
+    version = "0.4.1";
 
     src = fetchFromGitHub {
       owner = "kubernetes-sigs";
       repo = "controller-tools";
       rev = "v${version}";
-      sha256 = "0ix7m1fi06mhp8xxfg2r82jzyphzx2lm8jmx23l9ai654bcnnnwh";
+      sha256 = "0hbnz5my2bwds16hdb9fzbf2ri6lhpn3jd4si7z7lbaiv0zm429m";
     };
     subPackages = [ "cmd/controller-gen" ];
 


### PR DESCRIPTION
With Kubernetes no longer supporting `apiextensions.k8s.io/v1beta1` this
changeset updates the generated resource to using the v1 API.

I also correct a few spelling mistakes in the schema descriptions.