### PR TITLE
chore(helm): add chart for controller and service account

### DIFF
--- a/deploy/charts/origin-ca-issuer/Chart.yaml
+++ b/deploy/charts/origin-ca-issuer/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: origin-ca-issuer
+version: 0.5.0
+appVersion: 0.5.0
+description: A Helm chart for origin-ca-issuer
+home: https://github.com/cloudflare/origin-ca-issuer
+keywords:
+  - cert-manager
+  - cloudflare
+  - tls
+sources:
+  - https://github.com/cloudflare/origin-ca-issuer

--- a/deploy/charts/origin-ca-issuer/README.md
+++ b/deploy/charts/origin-ca-issuer/README.md
@@ -1,0 +1,82 @@
+# origin-ca-issuser
+
+origin-ca-issuer is a Kubernetes addon to automate issuance and renewals of Cloudflare Origin CA certificates with cert-manager.
+
+## Prerequisites
+
+* Kubernetes 1.16+
+* cert-manager 1.0.0+
+
+## Installing the Chart
+
+Before installing the chart, you must first install [cert-manager](https://cert-manager.io/docs/installation/), and the origin-ca-issuer CustomResourceDefinition resources.
+
+```shell
+VERSION="v0.5.0"
+kubectl apply -f https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/${VERSION}/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml
+```
+
+To install the chart with the release name `my-release`:
+
+``` shell
+helm install --name my-release --namespace origin-ca-issuer .
+```
+
+In order to begin issuer certificates from the Cloudflare Origin CA you will need to setup an OriginIssuer. For more information, see the [documentation])(https://github.com/cloudflare/origin-ca-issuer/blob/trunk/README.org).
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+``` shell
+helm delete my-release
+```
+If you want to completely uninstall origin-ca-issuer from your cluster, you also need to delete the previously installed CustomResourceDefinition resources:
+
+``` shell
+VERSION="v0.5.0"
+kubectl delete -f https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/${VERSION}/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml
+```
+
+## Configuration
+
+The following table lists the configurable parameters of the origin-ca-issuer chart and their default values.
+
+| Parameter                             | Description                                                                             | Default                          |
+|---------------------------------------|-----------------------------------------------------------------------------------------|----------------------------------|
+| `global.imagePullSecrets`             | Reference to one or more secrets to be used when pulling images                         | `[]`                             |
+| `global.rbac.create`                  | If `true`, create and use RBAC resources                                                | `true`                           |
+| `global.priorityClassName`            | Priority class name for origin-ca-issuer pods                                           | `""`                             |
+| `image.repository`                    | Image repository                                                                        | `cloudflare/origin-ca-issuer`    |
+| `image.tag`                           | Image tag                                                                               | `""`                             |
+| `image.digest`                        | Image digest                                                                            | `"sha256:{{ MANIFEST_DIGEST }}"` |
+| `image.pullPolicy`                    | Image pull policy                                                                       | `Always`                         |
+| `controller.deploymentAnnotations`    | Annotations to add to the origin-ca-issuer deployment                                   | `{}`                             |
+| `controller.deploymentLabels`         | Labels to add to the origin-ca-issuer deployment                                        | `{}`                             |
+| `controller.podAnntoations`           | Annotations to add to the origin-ca-issuer pods                                         | `{}`                             |
+| `controller.podLabels`                | Labels to add to the origin-ca-issuer pods.                                             | `{}`                             |
+| `controller.replicaCount`             | Number of origin-ca-issuer controller replicas                                          | `1`                              |
+| `controller.featureGates`             | Comma-seperated list of feature gates to enable on the controller pold                  | `""`                             |
+| `controller.extraArgs`                | Optional flags for origin-ca-issuer                                                     | `[]`                             |
+| `controller.extraEnv`                 | Optional environment variables for origin-ca-issuer                                     | `[]`                             |
+| `controller.serviceAccount.enable`    | If `true`, create a new service account                                                 | `true`                           |
+| `controller.serviceAccount.name`      | Service account to be used. If not set, a name is generated using the fullname template |                                  |
+| `controller.volumes`                  | Optional volumes for origin-ca-issuer                                                   | `[]`                             |
+| `controller.volumeMounts`             | Optional volume mounts for origin-ca-issuer                                             | `[]`                             |
+| `controller.securityContext`          | Optional security context. The YAML block should adhere to the SecurityContext spec     | `{}`                             |
+| `controller.containerSecurityContext` | Optional container security context                                                     | `{}`                             |
+| `controller.nodeSelector`             | Node labels for pod assignment                                                          | `{}`                             |
+| `controller.affinity`                 | Node (anti-)affinity for pod assignemt                                                  | `{}`                             |
+| `controller.tolerations`              | Node tolerations for pod assignment                                                     | `{}`                             |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML value that specifies the values for the above parameters can be provided while installing the chart. For example.
+
+``` shell
+helm install --name my-release -f values.yaml .
+```
+
+## Contributing
+
+This chart is maintained at [github.com/cloudflare/origin-ca-issuer](https://github.com/cloudflare/origin-ca-issuer).

--- a/deploy/charts/origin-ca-issuer/templates/_helpers.tpl
+++ b/deploy/charts/origin-ca-issuer/templates/_helpers.tpl
@@ -1,0 +1,42 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "origin-ca-issuer.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 50 chars because some Kubernetes name fields are limited to 63 (by the DNS naming spec),
+and we append in some places.
+*/}}
+{{- define "origin-ca-issuer.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 50 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 50 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 50 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "origin-ca-issuer.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "origin-ca-issuer.serviceAccountName" -}}
+{{- if .Values.controller.serviceAccount.create -}}
+    {{ default (include "origin-ca-issuer.fullname" .) .Values.controller.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.controller.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/origin-ca-issuer/templates/issuer-clusterrole.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/issuer-clusterrole.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.global.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "origin-ca-issuer.fullname" . }}-controller
+  labels:
+    app: {{ template "origin-ca-issuer.name" . }}
+    app.kubernetes.io/name: {{ template "origin-ca-issuer.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ template "origin-ca-issuer.chart" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificatrequests"]
+    verbs: ["get", "list", "update", "watch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificaterequests/status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["cert-manager.k8s.cloudflare.com"]
+    resources: ["originissuers"]
+    verbs: ["create", "get", "list", "watch"]
+  - apiGroups: ["cert-manager.k8s.cloudflare.com"]
+    resources: ["originissuers/status"]
+    verbs: ["get", "patch", "update"]
+{{- end }}

--- a/deploy/charts/origin-ca-issuer/templates/issuer-deployment.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/issuer-deployment.yaml
@@ -1,0 +1,84 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "origin-ca-issuer.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ template "origin-ca-issuer.name" . }}
+    app.kubernetes.io/name: {{ template "origin-ca-issuer.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ template "origin-ca-issuer.chart" . }}
+    {{- if .Values.controller.deploymentLabels }}
+{{ toYaml .Values.controller.deploymentLabels | indent 4 }}
+    {{- end }}
+  {{- if .Values.controller.deploymentAnnotations }}
+  annotations: {{ toYaml .Values.controller.deploymentAnnotations | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.controller.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "origin-ca-issuer.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: "controller"
+  {{- with .Values.controller.strategy }}
+  strategy: {{ toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "origin-ca-issuer.name" . }}
+        app.kubernetes.io/name: {{ template "origin-ca-issuer.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: "controller"
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        helm.sh/chart: {{ template "origin-ca-issuer.chart" . }}
+        {{- if .Values.controller.podLabels }}
+{{ toYaml .Values.controller.podLabels | indent 8 }}
+        {{- end}}
+      {{- if .Values.controller.podAnnotations }}
+      annotations: {{ toYaml .Values.controller.podAnnotations | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ template "origin-ca-issuer.serviceAccountName" . }}
+      {{- if .Values.global.priorityClassName }}
+      priorityClassName: {{ .Values.global.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.controller.securityContext }}
+      securityContext: {{ toYaml .Values.controller.securityContext | nindent 8 }}
+      {{- end }}
+      {{- if .Values.controller.volumes }}
+      volumes: {{ toYaml .Values.controller.volumes | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.controller.image }}
+          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{.digest}}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+          {{- if .Values.controller.containerSecurityContext }}
+          securityContext: {{- toYaml .Values.controller.containerSecurityContext | nindent 12 }}
+          {{- end}}
+          {{- if .Values.controller.volumeMounts }}
+          volumeMounts: {{ toYaml .Values.controller.volumeMounts | nindent 12 }}
+          {{- end }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- if .Values.controller.extraEnv }}
+{{ toYaml .Values.controller.extraEnv | indent 12 }}
+            {{- end }}
+      resources: {{ toYaml .Values.controller.resources | nindent 8 }}
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity: {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations: {{ toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/origin-ca-issuer/templates/issuer-rolebinding.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/issuer-rolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.global.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "origin-ca-issuer.fullname" . }}-controller
+  labels:
+    app: {{ template "origin-ca-issuer.name" . }}
+    app.kubernetes.io/name: {{ template "origin-ca-issuer.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ template "origin-ca-issuer.chart" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "origin-ca-issuer.fullname" . }}-controller
+subjects:
+  - name: {{ template "origin-ca-issuer.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+{{- end }}

--- a/deploy/charts/origin-ca-issuer/templates/issuer-serviceaccount.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/issuer-serviceaccount.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.controller.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- end }}
+metadata:
+  name: {{ template "origin-ca-issuer.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.controller.serviceAccount.annotations }}
+  annotations:
+    {{ toYaml .Values.controller.serviceAccount.annotations }}
+  {{- end }}
+  labels:
+    app: {{ include "origin-ca-issuer.name" . }}
+    app.kubernetes.io/name: {{ include "origin-ca-issuer.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ include "origin-ca-issuer.chart" . }}
+{{- end }}

--- a/deploy/charts/origin-ca-issuer/values.yaml
+++ b/deploy/charts/origin-ca-issuer/values.yaml
@@ -1,0 +1,90 @@
+# Declare values passed into templates.
+global:
+  # Optional reference to one or more secrets to be used when pulling secrets.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  #   imagePullSecrets:
+  #     - name: "my-image-pull-secret"
+  imagePullSecrets: []
+
+  # Optional priority class name to use on origin-ca-issuer pods
+  # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+  priorityClassName: ""
+
+  # Specifies whether RBAC resources should be created.
+  rbac:
+    create: true
+
+# Value specific to the origin-ca-issuer controller
+controller:
+  image:
+    repository: cloudflare/origin-ca-issuer
+    digest: sha256:76a0cadffd13cf77d75f6c1b7510ed8100706a776ad5a8d3345b192e8ac012d0
+    pullPolicy: Always
+
+  replicaCount: 1
+
+  # Optional deployment rollout strategy.
+  # ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  #   strategy:
+  #     rollingUpdate:
+  #       maxSurge: 0
+  #       maxUnavailable: 1
+  strategy: {}
+
+  # Optional additional arguments
+  extraArgs: []
+
+  # Optional additional environment variables
+  extraEnv: []
+
+  # Specifies the service account for the controller.
+  serviceAccount:
+    create: true
+    # The name of the service account to use. If not set, a name is generated based on the template's full name.
+    # name: ""
+    # Optional additional annotations to add to the controller's service account.
+    # annotations: {}
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 50Mi
+    requests:
+      cpu: 100m
+      memory: 50Mi
+
+  # Optional Pod Security Context
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  securityContext: {}
+
+  # Optional Container Security Context
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  containerSecurityContext: {}
+
+  # Optional volumes to use with the origin-ca-issuer pods
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/
+  volumes: []
+  volumeMounts: []
+
+  # Optional additional annotations to add to the deployment.
+  deploymentAnnotations: {}
+
+  # Optional additional labels to add to the deployment.
+  deploymentLabels: {}
+
+  # Optional additional annotations to add to the pods.
+  podAnnotations: {}
+
+  # Optional additional labels to add to the pods.
+  podLabels: {}
+
+  # Optional node selector for the deployment.
+  nodeSelector: {}
+
+  # Optional pod (anti-)affinities.
+  # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
+  affinity: {}
+
+  # Optional pod tolerations.
+  # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
+  tolerations: {}


### PR DESCRIPTION
Adds a chart of the controller deployment and the necessary service
accounts. This tries to follow the recommended conventions from the Helm
project. In particular, CustomResourceDefinition resources are not
installed by Helm.

Fixes #2