### PR TITLE
chore(deps): upgrade go to 1.16.2

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: nixbuild/nix-quick-install-action@v4
-      - run: nix-shell --pure --run "golangci-lint run --timeout 15m"
+      - run: nix-shell --pure --run "golangci-lint run --timeout 15m -e 'please use pkg/envtest for testing'"
   integration:
     needs:
       - unit

--- a/hack/nixpkgs.nix
+++ b/hack/nixpkgs.nix
@@ -1,6 +1,6 @@
 import (builtins.fetchTarball {
-  name = "nixos-unstable-2020-12-15";
+  name = "nixos-unstable-2021-03-16";
   url =
-    "https://github.com/NixOS/nixpkgs/archive/1b35b3d3a776e20e4595c47f2f97158c6d360309.tar.gz";
-  sha256 = "1m1b9wrsh6xhsjz2j80i59bpc3sdx7n5yq01hrjg47g790lhx58j";
+    "https://github.com/NixOS/nixpkgs/archive/266dc8c3d052f549826ba246d06787a219533b8f.tar.gz";
+  sha256 = "09ydqx2lznixmw8z4cfz1j3k137mh8n3cdpygwqymknhfdjq7lg4";
 })

--- a/shell.nix
+++ b/shell.nix
@@ -36,21 +36,21 @@ let
 
     vendorSha256 = "04nh4ql50w8w8zsqwg7rr0fz3lfnvky4l77rli8fpywg58z77n7k";
   };
+  # pin controller-runtime's envtest to Kubernetes 1.19.5 due to
+  # incompatibilites with 1.20:
+  #   https://github.com/kubernetes-sigs/controller-runtime/issues/1357
+  kubePkgs = import (builtins.fetchTarball {
+    name = "nixpkgs-2021-02-08-k8s-1.19.5";
+    url =
+      "https://github.com/NixOS/nixpkgs/archive/bed08131cd29a85f19716d9351940bdc34834492.tar.gz";
+    sha256 = "19gxrzk9y4g2f09x2a4g5699ccw35h5frznn9n0pbsyv45n9vxix";
+  }) { };
 
 in pkgs.mkShell {
-  nativeBuildInputs = [
-    go
-    gopls
-    goimports
-    golangci-lint
-    code-gen
-    controller-tools
-    etcd
-    kubernetes
-    kubectl
-  ];
+  nativeBuildInputs =
+    [ go gopls goimports golangci-lint code-gen controller-tools ];
 
-  TEST_ASSET_KUBE_APISERVER = "${kubernetes}/bin/kube-apiserver";
+  TEST_ASSET_KUBE_APISERVER = "${kubePkgs.kubernetes}/bin/kube-apiserver";
   TEST_ASSET_ETCD = "${etcd}/bin/etcd";
-  TEST_ASSET_KUBECTL = "${kubectl}/bin/kubectl";
+  TEST_ASSET_KUBECTL = "${kubePkgs.kubectl}/bin/kubectl";
 }


### PR DESCRIPTION
Upgrade the NixOS system to get updated components, including Go 1.16.2