### PR TITLE
Create a GitHub Actions to publish Helm chart

### DIFF
--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -3,7 +3,7 @@ name: Release Charts
 on:
   push:
     branches:
-      - master
+      - trunk
 
 jobs:
   release:

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -1,0 +1,31 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.0
+        with:
+          charts_repo_url: ${{ secrets.CHARTS_URL }}
+          charts_dir: deploy/charts
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Closes #17

---
This will auto publish a new release when you bump chart version.
`CHARTS_URL` has to be set in repo secrets, probably with this following: `https://cloudflare.github.io/origin-ca-issuer/`
A `gh-pages` branch is required.

https://github.com/helm/chart-releaser-action