### PR TITLE
fix(cfapi): only parse SignResponse when it exists

### DIFF
--- a/internal/cfapi/cfapi_test.go
+++ b/internal/cfapi/cfapi_test.go
@@ -1,7 +1,11 @@
 package cfapi
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -64,4 +68,94 @@ func TestSignResponse_Unmarshal(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSign(t *testing.T) {
+	expectedTime := time.Date(2020, time.December, 25, 6, 27, 0, 0, time.UTC)
+	tests := []struct {
+		name     string
+		handler  http.Handler
+		response *SignResponse
+		error    string
+	}{
+		{name: "API success",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, `{
+	"success": true,
+	"errors": [],
+	"message": [],
+	"result": {
+		"id":"9001",
+		"certificate":"-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",
+		"expires_on":"2020-12-25T06:27:00Z",
+		"request_type":"origin-ecc",
+		"hostnames":["example.com"],
+		"csr":"-----BEGIN CERTIFICATE REQUEST-----\n-----END CERTIFICATE REQUEST-----",
+		"requested_validity":7
+	}
+}`)
+			}),
+			response: &SignResponse{
+				Id:          "9001",
+				Certificate: "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",
+				Hostnames:   []string{"example.com"},
+				Expiration:  expectedTime,
+				Type:        "origin-ecc",
+				Validity:    7,
+				CSR:         "-----BEGIN CERTIFICATE REQUEST-----\n-----END CERTIFICATE REQUEST-----",
+			},
+			error: "",
+		},
+		{
+			name: "API error",
+			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintln(w, `{
+	"success": false,
+	"errors": [{"code": 9001, "message": "Over Nine Thousand!"}],
+	"message": [],
+	"result": {}
+}`)
+			}),
+			response: nil,
+			error:    "Cloudflare API Error code=9001 message=Over Nine Thousand!",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewTLSServer(tt.handler)
+			defer ts.Close()
+
+			client := New([]byte("v1.0-FFFF-FFFF"),
+				WithClient(ts.Client()),
+				Must(WithEndpoint(ts.URL)),
+			)
+			resp, err := client.Sign(context.Background(), &SignRequest{
+				Hostnames: []string{"example.com"},
+				Validity:  3600,
+				Type:      "MD4",
+				CSR:       "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+			})
+
+			if diff := cmp.Diff(resp, tt.response); diff != "" {
+				t.Fatalf("diff: (-want +got)\n%s", diff)
+			}
+
+			if tt.error != "" {
+				if diff := cmp.Diff(err.Error(), tt.error); diff != "" {
+					t.Fatalf("diff: (-want +got)\n%s", diff)
+				}
+			}
+		})
+	}
+
+}
+
+func Must(opt Options, err error) Options {
+	if err != nil {
+		panic("option constructo returned error " + err.Error())
+	}
+
+	return opt
 }


### PR DESCRIPTION
If the Cloudflare API returns an error, it is unlikely to have also sent
a valid response, resulting in failure trying to parse the expiration
time formats.

This changeset delays parsing the result field until after verifying the
error field.

Fixes #46