### PR TITLE
docs: fix typo in project name

### DIFF
--- a/deploy/charts/origin-ca-issuer/README.md
+++ b/deploy/charts/origin-ca-issuer/README.md
@@ -1,4 +1,4 @@
-# origin-ca-issuser
+# origin-ca-issuer
 
 origin-ca-issuer is a Kubernetes addon to automate issuance and renewals of Cloudflare Origin CA certificates with cert-manager.
 


### PR DESCRIPTION
Removes extra character breaking markdown link.