### PR TITLE
fix(provisioners): request correct signing type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/jetstack/cert-manager v1.7.2
 	github.com/rs/zerolog v1.25.0
 	github.com/spf13/pflag v1.0.5
+	gotest.tools/v3 v3.0.3
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0
 	k8s.io/client-go v0.24.0
@@ -53,6 +54,7 @@ require (
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -939,6 +939,7 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
+gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
 gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/hack/derivation.nix
+++ b/hack/derivation.nix
@@ -6,7 +6,7 @@ pkgs.buildGo117Module rec {
 
   src = lib.sourceFilesBySuffices ../. [ ".go" ".mod" ".sum" ];
 
-  vendorSha256 = "1qr3mh1ws9ff21qs6pf7d4hf5v1aw33zailzi9r3r6dykndjkhwg";
+  vendorSha256 = "sha256-YZYR6e07kZFcGYTGYJG6ywJI2sMJBOQi8I3m3GSgIBM=";
 
   subPackages = [ "cmd/controller" ];
 

--- a/pkgs/provisioners/origin_test.go
+++ b/pkgs/provisioners/origin_test.go
@@ -1,0 +1,192 @@
+package provisioners
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/cloudflare/origin-ca-issuer/internal/cfapi"
+	v1 "github.com/cloudflare/origin-ca-issuer/pkgs/apis/v1"
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	certmanager "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmgen "github.com/jetstack/cert-manager/test/unit/gen"
+	"gotest.tools/v3/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSign(t *testing.T) {
+	type testCase struct {
+		name     string
+		reqType  v1.RequestType
+		req      *certmanager.CertificateRequest
+		signReq  *cfapi.SignRequest
+		expected []byte
+	}
+
+	run := func(t *testing.T, tc testCase) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		signer := SignerFunc(func(ctx context.Context, req *cfapi.SignRequest) (*cfapi.SignResponse, error) {
+			assert.DeepEqual(t, req, tc.signReq, cmpopts.IgnoreFields(cfapi.SignRequest{}, "CSR"))
+			return &cfapi.SignResponse{
+				Certificate: "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n",
+			}, nil
+		})
+
+		provisioner, err := New(signer, tc.reqType, logr.Discard())
+		assert.NilError(t, err)
+
+		res, err := provisioner.Sign(ctx, tc.req)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, res, tc.expected)
+	}
+
+	testCases := []testCase{
+		{
+			name:    "origin rsa",
+			reqType: v1.RequestTypeOriginRSA,
+			req: cmgen.CertificateRequest("foobar",
+				cmgen.SetCertificateRequestNamespace("default"),
+				cmgen.SetCertificateRequestDuration(&metav1.Duration{Duration: 7 * 24 * time.Hour}),
+				cmgen.SetCertificateRequestCSR((func() []byte {
+					csr, _, err := cmgen.CSR(x509.RSA, cmgen.SetCSRDNSNames("example.com"))
+					assert.NilError(t, err)
+
+					return csr
+				})()),
+			),
+			signReq: &cfapi.SignRequest{
+				Hostnames: []string{"example.com"},
+				Validity:  7,
+				Type:      "origin-rsa",
+				CSR:       "",
+			},
+			expected: []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
+		},
+		{
+			name:    "origin ecc",
+			reqType: v1.RequestTypeOriginECC,
+			req: cmgen.CertificateRequest("foobar",
+				cmgen.SetCertificateRequestNamespace("default"),
+				cmgen.SetCertificateRequestDuration(&metav1.Duration{Duration: 7 * 24 * time.Hour}),
+				cmgen.SetCertificateRequestCSR((func() []byte {
+					csr, _, err := cmgen.CSR(x509.ECDSA, cmgen.SetCSRDNSNames("example.com"))
+					assert.NilError(t, err)
+
+					return csr
+				})()),
+			),
+			signReq: &cfapi.SignRequest{
+				Hostnames: []string{"example.com"},
+				Validity:  7,
+				Type:      "origin-ecc",
+				CSR:       "",
+			},
+			expected: []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
+		},
+		{
+			name:    "find closest duration",
+			reqType: v1.RequestTypeOriginECC,
+			req: cmgen.CertificateRequest("foobar",
+				cmgen.SetCertificateRequestNamespace("default"),
+				cmgen.SetCertificateRequestDuration(&metav1.Duration{Duration: 10 * 365 * 24 * time.Hour}),
+				cmgen.SetCertificateRequestCSR((func() []byte {
+					csr, _, err := cmgen.CSR(x509.ECDSA, cmgen.SetCSRDNSNames("example.com"))
+					assert.NilError(t, err)
+
+					return csr
+				})()),
+			),
+			signReq: &cfapi.SignRequest{
+				Hostnames: []string{"example.com"},
+				Validity:  5475,
+				Type:      "origin-ecc",
+				CSR:       "",
+			},
+			expected: []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
+		},
+		{
+			name:    "default duration",
+			reqType: v1.RequestTypeOriginECC,
+			req: cmgen.CertificateRequest("foobar",
+				cmgen.SetCertificateRequestNamespace("default"),
+				cmgen.SetCertificateRequestCSR((func() []byte {
+					csr, _, err := cmgen.CSR(x509.ECDSA, cmgen.SetCSRDNSNames("example.com"))
+					assert.NilError(t, err)
+
+					return csr
+				})()),
+			),
+			signReq: &cfapi.SignRequest{
+				Hostnames: []string{"example.com"},
+				Validity:  7,
+				Type:      "origin-ecc",
+				CSR:       "",
+			},
+			expected: []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"),
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			run(t, tc)
+		})
+	}
+}
+
+func TestSign_Error(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	signer := SignerFunc(func(ctx context.Context, req *cfapi.SignRequest) (*cfapi.SignResponse, error) {
+		return nil, errors.New("cfapi error")
+	})
+
+	req := cmgen.CertificateRequest("foobar",
+		cmgen.SetCertificateRequestNamespace("default"),
+		cmgen.SetCertificateRequestCSR((func() []byte {
+			csr, _, err := cmgen.CSR(x509.ECDSA, cmgen.SetCSRDNSNames("example.com"))
+			assert.NilError(t, err)
+
+			return csr
+		})()),
+	)
+
+	provisioner, err := New(signer, v1.RequestTypeOriginECC, logr.Discard())
+	assert.NilError(t, err)
+
+	_, err = provisioner.Sign(ctx, req)
+	assert.Error(t, err, "unable to sign request: cfapi error")
+}
+
+func TestClosest(t *testing.T) {
+	index := func(x int, s []int) int {
+		for i, n := range s {
+			if x == n {
+				return i
+			}
+		}
+
+		return -1
+	}
+
+	f := func(x int) bool {
+		d := closest(x, allowedValidty)
+		return index(d, allowedValidty) >= 0
+	}
+
+	err := quick.Check(f, nil)
+	assert.NilError(t, err)
+}
+
+type SignerFunc func(ctx context.Context, req *cfapi.SignRequest) (*cfapi.SignResponse, error)
+
+func (f SignerFunc) Sign(ctx context.Context, req *cfapi.SignRequest) (*cfapi.SignResponse, error) {
+	return f(ctx, req)
+}


### PR DESCRIPTION
The requested certificate type was backwards, so requesting an RSA signature resulted in an ECC signature from the Origin CA API and vice-versa.

This changeset corrects the requested signature type, and adds tests to verify the provisioner's behaviors.

Fixes #72