### PR TITLE
fix(helm): update labels to comply with kubernetes recommended labels

### DIFF
--- a/deploy/charts/origin-ca-issuer/templates/issuer-clusterrole.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/issuer-clusterrole.yaml
@@ -4,7 +4,6 @@ kind: ClusterRole
 metadata:
   name: {{ template "origin-ca-issuer.fullname" . }}-controller
   labels:
-    app: {{ template "origin-ca-issuer.name" . }}
     app.kubernetes.io/name: {{ template "origin-ca-issuer.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -36,7 +35,6 @@ kind: ClusterRole
 metadata:
   name: cert-manager-controller-approve:cert-manager-k8s-cloudflare-com
   labels:
-    app: {{ template "origin-ca-issuer.name" . }}
     app.kubernetes.io/name: {{ template "origin-ca-issuer.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/deploy/charts/origin-ca-issuer/templates/issuer-deployment.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/issuer-deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: {{ template "origin-ca-issuer.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
-    app: {{ template "origin-ca-issuer.name" . }}
     app.kubernetes.io/name: {{ template "origin-ca-issuer.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -29,7 +28,6 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "origin-ca-issuer.name" . }}
         app.kubernetes.io/name: {{ template "origin-ca-issuer.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: "controller"

--- a/deploy/charts/origin-ca-issuer/templates/issuer-rolebinding.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/issuer-rolebinding.yaml
@@ -4,7 +4,6 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ template "origin-ca-issuer.fullname" . }}-controller
   labels:
-    app: {{ template "origin-ca-issuer.name" . }}
     app.kubernetes.io/name: {{ template "origin-ca-issuer.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
@@ -26,7 +25,6 @@ kind: ClusterRoleBinding
 metadata:
   name: cert-manager-controller-approve:cert-manager-k8s-cloudflare-com
   labels:
-    app: {{ template "origin-ca-issuer.name" . }}
     app.kubernetes.io/name: {{ template "origin-ca-issuer.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/deploy/charts/origin-ca-issuer/templates/issuer-serviceaccount.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/issuer-serviceaccount.yaml
@@ -12,7 +12,6 @@ metadata:
     {{ toYaml .Values.controller.serviceAccount.annotations }}
   {{- end }}
   labels:
-    app: {{ include "origin-ca-issuer.name" . }}
     app.kubernetes.io/name: {{ include "origin-ca-issuer.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -6,12 +6,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: origin-ca-issuer
+      app.kubernetes.io/name: origin-ca-issuer
   replicas: 1
   template:
     metadata:
       labels:
-        app: origin-ca-issuer
+        app.kubernetes.io/name: origin-ca-issuer
     spec:
       serviceAccountName: originissuer-control
       containers:


### PR DESCRIPTION
Per https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
the label `app` should no longer be used and rather `app.kubernetes.io/name`
instead.
