### PR TITLE
Fix Helm string-substitution syntax

### DIFF
--- a/deploy/charts/origin-ca-issuer/Chart.yaml
+++ b/deploy/charts/origin-ca-issuer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: origin-ca-issuer
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.6.1
 description: A Helm chart for origin-ca-issuer
 home: https://github.com/cloudflare/origin-ca-issuer

--- a/deploy/charts/origin-ca-issuer/README.md
+++ b/deploy/charts/origin-ca-issuer/README.md
@@ -22,7 +22,7 @@ To install the chart with the release name `my-release`:
 helm install --name my-release --namespace origin-ca-issuer .
 ```
 
-In order to begin issuer certificates from the Cloudflare Origin CA you will need to setup an OriginIssuer. For more information, see the [documentation](https://github.com/cloudflare/origin-ca-issuer/blob/trunk/README.org).
+In order to begin issuing certificates from the Cloudflare Origin CA you will need to set up an OriginIssuer. For more information, see the [documentation](https://github.com/cloudflare/origin-ca-issuer/blob/trunk/README.org).
 
 ## Uninstalling the Chart
 
@@ -56,7 +56,7 @@ The following table lists the configurable parameters of the origin-ca-issuer ch
 | `controller.podAnntoations`           | Annotations to add to the origin-ca-issuer pods                                         | `{}`                             |
 | `controller.podLabels`                | Labels to add to the origin-ca-issuer pods.                                             | `{}`                             |
 | `controller.replicaCount`             | Number of origin-ca-issuer controller replicas                                          | `1`                              |
-| `controller.featureGates`             | Comma-seperated list of feature gates to enable on the controller pod                   | `""`                             |
+| `controller.featureGates`             | Comma-separated list of feature gates to enable on the controller pod                   | `""`                             |
 | `controller.extraArgs`                | Optional flags for origin-ca-issuer                                                     | `[]`                             |
 | `controller.extraEnv`                 | Optional environment variables for origin-ca-issuer                                     | `[]`                             |
 | `controller.serviceAccount.enable`    | If `true`, create a new service account                                                 | `true`                           |
@@ -66,11 +66,11 @@ The following table lists the configurable parameters of the origin-ca-issuer ch
 | `controller.securityContext`          | Optional security context. The YAML block should adhere to the SecurityContext spec     | `{}`                             |
 | `controller.containerSecurityContext` | Optional container security context                                                     | `{}`                             |
 | `controller.nodeSelector`             | Node labels for pod assignment                                                          | `{}`                             |
-| `controller.affinity`                 | Node (anti-)affinity for pod assignemt                                                  | `{}`                             |
+| `controller.affinity`                 | Node (anti-)affinity for pod assignment                                                  | `{}`                             |
 | `controller.tolerations`              | Node tolerations for pod assignment                                                     | `{}`                             |
 | `controller.disableApprovedCheck`     | Disable waiting for CertificateRequests to be Approved before signing                   | `false`                          |
-| `cert-manager.namespace `             | Namespace where the cert-manager controller is running.                                 | `cert-manager`                   |
-| `cert-manager.serviceAccountName`     | The Service Account used by the cert-manager controller.                                | `cert-manager`                   |
+| `certmanager.namespace`             | Namespace where the cert-manager controller is running.                                 | `cert-manager`                   |
+| `certmanager.serviceAccountName`     | The Service Account used by the cert-manager controller.                                | `cert-manager`                   |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/deploy/charts/origin-ca-issuer/templates/issuer-rolebinding.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/issuer-rolebinding.yaml
@@ -38,6 +38,6 @@ roleRef:
   name: cert-manager-controller-approve:cert-manager-k8s-cloudflare-com
 subjects:
 - kind: ServiceAccount
-  name: {{ template "cert-manager.serviceAccountName" . }}
-  namespace: {{ template "cert-manager.namespace" . }}
+  name: {{ .Values.certmanager.serviceAccountName }}
+  namespace: {{ .Values.certmanager.namespace }}
 {{- end }}

--- a/deploy/charts/origin-ca-issuer/values.yaml
+++ b/deploy/charts/origin-ca-issuer/values.yaml
@@ -92,6 +92,6 @@ controller:
   # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
   tolerations: {}
 
-cert-manager:
+certmanager:
   namespace: cert-manager
   serviceAccountName: cert-manager


### PR DESCRIPTION
Thanks for maintaining this project @terinjokes ! 🙏🏻

This PR should resolve #90 and resolve #88. Also made a few typo fixes, but I can separate those out if preferred.

## Notes

### Change was tested via `helm template`

Here is the before and after:

```shell
# before (error)
❯ helm template cf-sa deploy/charts/origin-ca-issuer/
Error: template: origin-ca-issuer/templates/issuer-rolebinding.yaml:41:20: executing "origin-ca-issuer/templates/issuer-rolebinding.yaml" at <{{template "cert-manager.serviceAccountName" .}}>: template "cert-manager.serviceAccountName" not defined
```
```shell
# after (successful manifest output)
❯ helm template cf-sa deploy/charts/origin-ca-issuer/
---
# Source: origin-ca-issuer/templates/issuer-serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
...
```

### The naming of the `cert-manager`/`certmanager` values object is up for debate

I removed the hyphen from the `cert-manager.*` values object, since hyphens in Helm are uncommon AFAIK. 

However, it's still possible to use them if we/you would like, using Helm's `index` function: https://github.com/helm/helm/issues/2192#issuecomment-293739257