### PR TITLE
chore(helm): actions for charts

### DIFF
--- a/.github/workflows/charts.yaml
+++ b/.github/workflows/charts.yaml
@@ -1,0 +1,45 @@
+name: Test Charts
+on:
+  - pull_request
+  - push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  chart-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: azure/setup-helm@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          check-latest: true
+      - uses: helm/chart-testing-action@v2
+      - name: chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs deploy/charts)
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --chart-dirs deploy/charts --check-version-increment=false --github-groups
+      - uses: helm/kind-action@v1
+        if: steps.list-changed.outputs.changed == 'true'
+      - name: chart-testing (install)
+        if: steps.list-changed.outputs.changed == 'true' && ! startsWith(github.ref, 'refs/tags/v')
+        run: |
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.crds.yaml
+          kubectl apply -f ./deploy/crds
+          ct install --target-branch ${{ github.event.repository.default_branch }} --chart-dirs deploy/charts --github-groups
+      - name: helm package
+        run: helm package deploy/charts/origin-ca-issuer
+      - name: helm publish
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login -u ${{ github.actor }} --password-stdin ghcr.io
+          helm push origin-ca-issuer-*.tgz oci://ghcr.io/cloudflare/origin-ca-issuer-charts

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,6 +2,9 @@ name: Docker
 on:
   - pull_request
   - push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,6 +2,9 @@ name: Test
 on:
   - pull_request
   - push
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   unit:
     runs-on: ubuntu-latest

--- a/deploy/charts/origin-ca-issuer/Chart.yaml
+++ b/deploy/charts/origin-ca-issuer/Chart.yaml
@@ -1,9 +1,12 @@
-apiVersion: v1
+apiVersion: v2
+type: application
 name: origin-ca-issuer
 version: 0.5.1
 appVersion: 0.6.1
 description: A Helm chart for origin-ca-issuer
 home: https://github.com/cloudflare/origin-ca-issuer
+maintainers:
+  - name: terinjokes
 keywords:
   - cert-manager
   - cloudflare


### PR DESCRIPTION
Create a GitHub Action that for the origin-ca-issuer Helm chart that
lints, tests installing to a KinD cluster, and publishes to an OCI
registry on new releases.

Bug: #90
Bug: #97