### PR TITLE
fix(actions): publish chart independently

### DIFF
--- a/.github/workflows/charts.yaml
+++ b/.github/workflows/charts.yaml
@@ -27,19 +27,20 @@ jobs:
           fi
       - name: chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --chart-dirs deploy/charts --check-version-increment=false --github-groups
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --chart-dirs deploy/charts --github-groups
       - uses: helm/kind-action@v1
         if: steps.list-changed.outputs.changed == 'true'
       - name: chart-testing (install)
-        if: steps.list-changed.outputs.changed == 'true' && ! startsWith(github.ref, 'refs/tags/v')
+        if: steps.list-changed.outputs.changed == 'true'
         run: |
           kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.3/cert-manager.crds.yaml
           kubectl apply -f ./deploy/crds
           ct install --target-branch ${{ github.event.repository.default_branch }} --chart-dirs deploy/charts --github-groups
       - name: helm package
+        if: steps.list-changed.outputs.changed == 'true'
         run: helm package deploy/charts/origin-ca-issuer
       - name: helm publish
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: steps.list-changed.outputs.changed == 'true' && (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | helm registry login -u ${{ github.actor }} --password-stdin ghcr.io
           helm push origin-ca-issuer-*.tgz oci://ghcr.io/cloudflare/origin-ca-issuer-charts


### PR DESCRIPTION
The Helm chart will be modified and released independently from tagged versions of the controller. This allows us to update and test the chart after new releases of the controller, as well as making improvements or bugfixes to it.

This changeset modifies the action to publish new versions of charts whenever there is a change on the main branch.