### PR TITLE
chore(deploy): increase cpu and memory

### DIFF
--- a/deploy/charts/origin-ca-issuer/Chart.yaml
+++ b/deploy/charts/origin-ca-issuer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: origin-ca-issuer
-version: 0.5.2
+version: 0.5.3
 appVersion: 0.7.0
 description: A Helm chart for origin-ca-issuer
 home: https://github.com/cloudflare/origin-ca-issuer

--- a/deploy/charts/origin-ca-issuer/README.md
+++ b/deploy/charts/origin-ca-issuer/README.md
@@ -42,35 +42,36 @@ kubectl delete -f https://raw.githubusercontent.com/cloudflare/origin-ca-issuer/
 
 The following table lists the configurable parameters of the origin-ca-issuer chart and their default values.
 
-| Parameter                             | Description                                                                             | Default                          |
-|---------------------------------------|-----------------------------------------------------------------------------------------|----------------------------------|
-| `global.imagePullSecrets`             | Reference to one or more secrets to be used when pulling images                         | `[]`                             |
-| `global.rbac.create`                  | If `true`, create and use RBAC resources                                                | `true`                           |
-| `global.priorityClassName`            | Priority class name for origin-ca-issuer pods                                           | `""`                             |
-| `image.repository`                    | Image repository                                                                        | `cloudflare/origin-ca-issuer`    |
-| `image.tag`                           | Image tag                                                                               | `""`                             |
-| `image.digest`                        | Image digest                                                                            | `"sha256:{{ MANIFEST_DIGEST }}"` |
-| `image.pullPolicy`                    | Image pull policy                                                                       | `Always`                         |
-| `controller.deploymentAnnotations`    | Annotations to add to the origin-ca-issuer deployment                                   | `{}`                             |
-| `controller.deploymentLabels`         | Labels to add to the origin-ca-issuer deployment                                        | `{}`                             |
-| `controller.podAnntoations`           | Annotations to add to the origin-ca-issuer pods                                         | `{}`                             |
-| `controller.podLabels`                | Labels to add to the origin-ca-issuer pods.                                             | `{}`                             |
-| `controller.replicaCount`             | Number of origin-ca-issuer controller replicas                                          | `1`                              |
-| `controller.featureGates`             | Comma-separated list of feature gates to enable on the controller pod                   | `""`                             |
-| `controller.extraArgs`                | Optional flags for origin-ca-issuer                                                     | `[]`                             |
-| `controller.extraEnv`                 | Optional environment variables for origin-ca-issuer                                     | `[]`                             |
-| `controller.serviceAccount.enable`    | If `true`, create a new service account                                                 | `true`                           |
-| `controller.serviceAccount.name`      | Service account to be used. If not set, a name is generated using the fullname template |                                  |
-| `controller.volumes`                  | Optional volumes for origin-ca-issuer                                                   | `[]`                             |
-| `controller.volumeMounts`             | Optional volume mounts for origin-ca-issuer                                             | `[]`                             |
-| `controller.securityContext`          | Optional security context. The YAML block should adhere to the SecurityContext spec     | `{}`                             |
-| `controller.containerSecurityContext` | Optional container security context                                                     | `{}`                             |
-| `controller.nodeSelector`             | Node labels for pod assignment                                                          | `{}`                             |
-| `controller.affinity`                 | Node (anti-)affinity for pod assignment                                                 | `{}`                             |
-| `controller.tolerations`              | Node tolerations for pod assignment                                                     | `{}`                             |
-| `controller.disableApprovedCheck`     | Disable waiting for CertificateRequests to be Approved before signing                   | `false`                          |
-| `certmanager.namespace`               | Namespace where the cert-manager controller is running.                                 | `cert-manager`                   |
-| `certmanager.serviceAccountName`      | The Service Account used by the cert-manager controller.                                | `cert-manager`                   |
+| Parameter                             | Description                                                                             | Default                                                                        |
+|---------------------------------------|-----------------------------------------------------------------------------------------|--------------------------------------------------------------------------------|
+| `global.imagePullSecrets`             | Reference to one or more secrets to be used when pulling images                         | `[]`                                                                           |
+| `global.rbac.create`                  | If `true`, create and use RBAC resources                                                | `true`                                                                         |
+| `global.priorityClassName`            | Priority class name for origin-ca-issuer pods                                           | `""`                                                                           |
+| `image.repository`                    | Image repository                                                                        | `cloudflare/origin-ca-issuer`                                                  |
+| `image.tag`                           | Image tag                                                                               | `""`                                                                           |
+| `image.digest`                        | Image digest                                                                            | `"sha256:{{ MANIFEST_DIGEST }}"`                                               |
+| `image.pullPolicy`                    | Image pull policy                                                                       | `Always`                                                                       |
+| `controller.deploymentAnnotations`    | Annotations to add to the origin-ca-issuer deployment                                   | `{}`                                                                           |
+| `controller.deploymentLabels`         | Labels to add to the origin-ca-issuer deployment                                        | `{}`                                                                           |
+| `controller.podAnntoations`           | Annotations to add to the origin-ca-issuer pods                                         | `{}`                                                                           |
+| `controller.podLabels`                | Labels to add to the origin-ca-issuer pods.                                             | `{}`                                                                           |
+| `controller.replicaCount`             | Number of origin-ca-issuer controller replicas                                          | `1`                                                                            |
+| `controller.featureGates`             | Comma-separated list of feature gates to enable on the controller pod                   | `""`                                                                           |
+| `controller.extraArgs`                | Optional flags for origin-ca-issuer                                                     | `[]`                                                                           |
+| `controller.extraEnv`                 | Optional environment variables for origin-ca-issuer                                     | `[]`                                                                           |
+| `controller.serviceAccount.enable`    | If `true`, create a new service account                                                 | `true`                                                                         |
+| `controller.serviceAccount.name`      | Service account to be used. If not set, a name is generated using the fullname template |                                                                                |
+| `controller.volumes`                  | Optional volumes for origin-ca-issuer                                                   | `[]`                                                                           |
+| `controller.volumeMounts`             | Optional volume mounts for origin-ca-issuer                                             | `[]`                                                                           |
+| `controller.securityContext`          | Optional security context. The YAML block should adhere to the SecurityContext spec     | `{}`                                                                           |
+| `controller.containerSecurityContext` | Optional container security context                                                     | `{}`                                                                           |
+| `controller.nodeSelector`             | Node labels for pod assignment                                                          | `{}`                                                                           |
+| `controller.affinity`                 | Node (anti-)affinity for pod assignment                                                 | `{}`                                                                           |
+| `controller.tolerations`              | Node tolerations for pod assignment                                                     | `{}`                                                                           |
+| `controller.disableApprovedCheck`     | Disable waiting for CertificateRequests to be Approved before signing                   | `false`                                                                        |
+| `controller.resources`                | The resource request and limits.                                                        | `{requests: {cpu: "1", memory: "512Mi"}, limits: {cpu: "1", memory: "512Mi"}}` |
+| `certmanager.namespace`               | Namespace where the cert-manager controller is running.                                 | `cert-manager`                                                                 |
+| `certmanager.serviceAccountName`      | The Service Account used by the cert-manager controller.                                | `cert-manager`                                                                 |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/deploy/charts/origin-ca-issuer/values.yaml
+++ b/deploy/charts/origin-ca-issuer/values.yaml
@@ -50,11 +50,11 @@ controller:
 
   resources:
     limits:
-      cpu: 100m
-      memory: 50Mi
+      cpu: "1"
+      memory: 512Mi
     requests:
-      cpu: 100m
-      memory: 50Mi
+      cpu: "1"
+      memory: 512Mi
 
   # Optional Pod Security Context
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -19,9 +19,9 @@ spec:
           name: origin-ca-controller
           resources:
             limits:
-              cpu: 100m
-              memory: 100Mi
+              cpu: "1"
+              memory: 512Mi
             requests:
-              cpu: 100m
-              memory: 100Mi
+              cpu: "1"
+              memory: 512Mi
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
The CPU and memory limits of the controller are intended to be tuned by cluster administrators, however it presents a better experience if the defaults work out of the box.

This changeset increases the requests and limits, and documents the fields in the chart documentation.

Bug: #118