### PR TITLE
feat: remove provisioners.Collection

### DIFF
--- a/pkgs/controllers/originissuer_suite_test.go
+++ b/pkgs/controllers/originissuer_suite_test.go
@@ -14,7 +14,6 @@ import (
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/cloudflare/origin-ca-issuer/internal/cfapi"
 	v1 "github.com/cloudflare/origin-ca-issuer/pkgs/apis/v1"
-	"github.com/cloudflare/origin-ca-issuer/pkgs/provisioners"
 	"github.com/go-logr/zerologr"
 	"github.com/rs/zerolog"
 	corev1 "k8s.io/api/core/v1"
@@ -94,11 +93,11 @@ func TestOriginIssuerReconcileSuite(t *testing.T) {
 	})
 
 	controller := &OriginIssuerController{
-		Client:     c,
-		Clock:      clock.RealClock{},
-		Factory:    f,
-		Log:        logf.Log,
-		Collection: provisioners.CollectionWith(nil),
+		Client:  c,
+		Reader:  c,
+		Clock:   clock.RealClock{},
+		Factory: f,
+		Log:     logf.Log,
 	}
 
 	builder.ControllerManagedBy(mgr).
@@ -137,15 +136,6 @@ func TestOriginIssuerReconcileSuite(t *testing.T) {
 
 		return IssuerHasCondition(iss, v1.OriginIssuerCondition{Type: v1.ConditionReady, Status: v1.ConditionTrue})
 	}, 5*time.Second, 10*time.Millisecond, "OriginIssuer reconciler")
-
-	_, ok := controller.Collection.Load(types.NamespacedName{
-		Namespace: issuer.Namespace,
-		Name:      issuer.Name,
-	})
-
-	if !ok {
-		t.Fatal("was unable to find provisioner")
-	}
 }
 
 func StartTestManager(mgr manager.Manager, t *testing.T) (context.CancelFunc, chan error) {


### PR DESCRIPTION
The controller was creating an instance of a signing provisioner in the OriginIssuer reconciler, as an attempt to optimize against creating new API clients. As the certificates issued by the Origin API are valid for a minimium of 7 days this seems like a premature optimization. As the reconciler was not watching the service key secret for updates, it was also persisting stale API tokens.

This changeset removes the concept of the provisioner collection. A new API client and provisioner will be created as needed in the OriginIssuer reconciler. This allows users to update their API token without needing to restart the controller.

Fixes: ##109