### PR TITLE
fix(helm): Add ClusterOriginIssuers to approver ClusterRole

### DIFF
--- a/deploy/charts/origin-ca-issuer/Chart.yaml
+++ b/deploy/charts/origin-ca-issuer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: origin-ca-issuer
-version: 0.5.6
+version: 0.5.7
 appVersion: 0.9.0
 description: A Helm chart for origin-ca-issuer
 home: https://github.com/cloudflare/origin-ca-issuer

--- a/deploy/charts/origin-ca-issuer/templates/issuer-clusterrole.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/issuer-clusterrole.yaml
@@ -51,4 +51,5 @@ rules:
     - approve
     resourceNames:
     - originissuers.cert-manager.k8s.cloudflare.com/*
+    - clusteroriginissuers.cert-manager.k8s.cloudflare.com/*
 {{- end }}


### PR DESCRIPTION
`cert-manager` was unable to process the Approval action of a certificate when using `ClusterOriginIssuer`, the pod was showing:

```
 1 conditions.go:263] Setting lastTransitionTime for CertificateRequest "test-tls-1" condition "Approved" to 2024-07-10 08:57:28.083240782 +0000 UTC m=+600872.378883246
E0710 08:57:28.093648       1 controller.go:162] "re-queuing item due to error processing" err="admission webhook \"webhook.cert-manager.io\" denied the request: status.conditions: Forbidden: user \"system:serviceaccount:cert-manager:cert-manager\" does not have permissions to set approved/denied conditions for issuer {cf-cluster-origin-issuer ClusterOriginIssuer cert-manager.k8s.cloudflare.com}" logger="cert-manager.controller" key="my-site/test-tls-1"
```

Turns out the `ClusterRole` manifest in the helm chart was missing the `clusteroriginissuers.cert-manager.k8s.cloudflare.com/*` resourceName, adding it fixed the issue.