### PR TITLE
Fix deployment manifest

### DIFF
--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         - name: origin-ca-controller
           image: cloudflare/origin-ca-issuer:v0.9.0
           args:
-            - --cluster-resource-namespace=${POD_NAMESPACE}
+            - --cluster-resource-namespace=$(POD_NAMESPACE)
           env:
             - name: POD_NAMESPACE
               valueFrom:


### PR DESCRIPTION
With manifests installation, it's impossible to create a valid ClusterOriginIssuer.
According to the logs, the controller was unable to access the secret.
After debugging, the namespace used for secrets was not correctly passed as container argument...
This MR is here to fix that ;)