### PR TITLE
chore(suite): remove build tags

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,6 @@ jobs:
           go-version: "stable"
       - uses: dominikh/staticcheck-action@v1
         with:
-          build-tags: suite
           install-go: false
   integration:
     needs:
@@ -36,7 +35,8 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: "stable"
-      - run: |
+      - name: integration
+        run: |
           go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
           source <(setup-envtest use -p env)
-          go test ./... -tags suite
+          make test


### PR DESCRIPTION
The integration suite was guarded behind the "suite" build tag, which prevented Go tooling from working with the integration tests by default. This made the upcoming refactoring to support API tokens more difficult, and has historically discouraged the addition of more integration tests.

As modern versions of Go support `testing.Cleanup` we can move the envtest setup into a helper function that runs, and automatically cleans up, in every test, instead of wrapping the main function. The tests are guarded by checking for the presence of the KUBEBUILDER_ASSETS environment variable, which is set by `setup-env` in the CI environment.