### PR TITLE
fixes #153 Update values.yaml tolerations: [] instead of {}

### DIFF
--- a/deploy/charts/origin-ca-issuer/values.yaml
+++ b/deploy/charts/origin-ca-issuer/values.yaml
@@ -94,6 +94,10 @@ controller:
 
   # Optional pod tolerations.
   # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
+  #   tolerations:
+  #     - key: "CriticalAddonsOnly"
+  #       operator: "Exists"
+  #       effect: "NoSchedule"
   tolerations: []
 
 certmanager:

--- a/deploy/charts/origin-ca-issuer/values.yaml
+++ b/deploy/charts/origin-ca-issuer/values.yaml
@@ -94,7 +94,7 @@ controller:
 
   # Optional pod tolerations.
   # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
-  tolerations: {}
+  tolerations: []
 
 certmanager:
   namespace: cert-manager


### PR DESCRIPTION
fixes #153

`tolerations:` must be with `[]` instead of `{}` for people to actually use it with
```
- key: "CriticalAddonsOnly"
  operator: "Exists"
  effect: "NoSchedule"
```