### PR TITLE
Added secret reference and OriginIssuer

### DIFF
--- a/deploy/charts/origin-ca-issuer/README.md
+++ b/deploy/charts/origin-ca-issuer/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the origin-ca-issuer ch
 | `image.tag`                           | Image tag                                                                               | `""`                                                                           |
 | `image.digest`                        | Image digest                                                                            | `"sha256:{{ MANIFEST_DIGEST }}"`                                               |
 | `image.pullPolicy`                    | Image pull policy                                                                       | `Always`                                                                       |
+| `global.secretKeyRef`                 | Create secret for authentication with Cloudflare (refer to OriginIssuer)                | `[]`                                                                           |
 | `controller.deploymentAnnotations`    | Annotations to add to the origin-ca-issuer deployment                                   | `{}`                                                                           |
 | `controller.deploymentLabels`         | Labels to add to the origin-ca-issuer deployment                                        | `{}`                                                                           |
 | `controller.podAnntoations`           | Annotations to add to the origin-ca-issuer pods                                         | `{}`                                                                           |
@@ -71,6 +72,7 @@ The following table lists the configurable parameters of the origin-ca-issuer ch
 | `controller.disableApprovedCheck`     | Disable waiting for CertificateRequests to be Approved before signing                   | `false`                                                                        |
 | `controller.clusterResourceNamespace` | Override the namespace used for ClusterOriginIssuer secrets                             | `""`                                                                           |
 | `controller.resources`                | The resource request and limits.                                                        | `{requests: {cpu: "1", memory: "512Mi"}, limits: {cpu: "1", memory: "512Mi"}}` |
+| `controller.originIssuer`             | Issue Cloudflare certificates as an external cert-manager issuer                        | `[]`                                                                           |
 | `certmanager.namespace`               | Namespace where the cert-manager controller is running.                                 | `cert-manager`                                                                 |
 | `certmanager.serviceAccountName`      | The Service Account used by the cert-manager controller.                                | `cert-manager`                                                                 |
 

--- a/deploy/charts/origin-ca-issuer/templates/_helpers.tpl
+++ b/deploy/charts/origin-ca-issuer/templates/_helpers.tpl
@@ -40,3 +40,7 @@ Create the name of the service account to use
     {{ default "default" .Values.controller.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{- define "origin-ca-issuer.controller.originIssuer" -}}
+{{- default .Chart.Name .Values.controller.originIssuer.nameIssuerOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deploy/charts/origin-ca-issuer/templates/origin-issuer.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/origin-issuer.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.controller.originIssuer -}}
+apiVersion: cert-manager.k8s.cloudflare.com/v1
+kind: OriginIssuer
+metadata:
+  name: {{ template "origin-ca-issuer.controller.originIssuer" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "origin-ca-issuer.name" . }}
+    app.kubernetes.io/name: {{ include "origin-ca-issuer.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}  
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ template "origin-ca-issuer.chart" . }}  
+spec:
+  requestType: {{ default "OriginECC" .Values.controller.originIssuer.requestType }}
+  auth:
+  {{ default "ServiceKeyRef" .Values.controller.originIssuer.auth.type | indent 2 }}:
+{{- if .Values.global.secretKeyRef }}
+      name: {{ .Values.global.secretKeyRef.name }}
+      key: {{ .Values.global.secretKeyRef.key }}
+{{- else }}
+      name: {{ required "Reference to secret is required" .Values.controller.originIssuer.auth.secretName }}
+      key: {{ required "Reference to key is required" .Values.controller.originIssuer.auth.secretKey }}
+{{- end }}
+{{- end -}}

--- a/deploy/charts/origin-ca-issuer/templates/secretkeyref.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/secretkeyref.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.global.secretKeyRef -}}
+apiVersion: v1
+kind: Secret
+data:
+  {{ required "Key within secret is required" .Values.global.secretKeyRef.key }}: {{ required "Value within secret key is required" .Values.global.secretKeyRef.value | b64enc }}
+metadata:
+  name: {{ required "Name of secret is required" .Values.global.secretKeyRef.name }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "origin-ca-issuer.name" . }}
+    app.kubernetes.io/name: {{ include "origin-ca-issuer.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}  
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/component: "controller"
+    helm.sh/chart: {{ template "origin-ca-issuer.chart" . }}  
+type: Opaque
+{{- end -}}

--- a/deploy/charts/origin-ca-issuer/values.yaml
+++ b/deploy/charts/origin-ca-issuer/values.yaml
@@ -14,6 +14,14 @@ global:
   rbac:
     create: true
 
+#  Optional create a secret for key / token to authenticate with Cloudflare API
+  # secretKeyRef:
+  #   name: secret-name
+  #   key: secret-key
+  #   value: secret-value-within-key
+  secretKeyRef: []
+
+
 # Value specific to the origin-ca-issuer controller
 controller:
   image:
@@ -99,6 +107,16 @@ controller:
   #       operator: "Exists"
   #       effect: "NoSchedule"
   tolerations: []
+
+  # Optional issue Cloudflare certificates as an external cert-manager issuer (apiVersion cert-manager.k8s.cloudflare.com/v1)
+  # originIssuer:
+  #   nameIssuerOverride: defaults to chart name
+  #   requestTypes: OriginECC or OriginRSA (default OriginECC)
+  #   auth: configures settings for authentication with the Cloudflare API
+  #     type: serviceKeyRef or tokenRef (default serviceKeyRef)
+  #     secretName: reference to name of secret within namespace, defaults to globa.secretKeyRef.name
+  #     secretKey: reference to key within secret defaults to global.secretKeyRef.key
+  originIssuer: []
 
 certmanager:
   namespace: cert-manager


### PR DESCRIPTION
Providing Helm charts as complete as possible, avoiding manual creation of secret and OriginIssuer.
This makes it possible to handle components (secret + OriginIssuer) for the origin-ca-issuer as part of the release itself.

- Updated README.md
- Adjusted _helpers.tpl (to be in-line with current setup)
- Adjusted values.yaml (including some documentation)
- Added origin-issuer.yaml
-  secretkeyref.yaml

These changes have been tested, if some names are not very appropriate.. feel free to add comments.

Thank you 