### PR TITLE
docs: discourage Origin CA Keys

### DIFF
--- a/README.org
+++ b/README.org
@@ -39,7 +39,7 @@ pod/origin-ca-issuer-1234568-abcdw  1/1     Running     0           1m
 
 *** Adding an OriginIssuer
 **** API Token
-Origin CA Issuer can use an [[https://dash.cloudflare.com/profile/api-tokens][API Token]] that contains the "SSL and Certificates" permission, which can be scoped to specific accounts or zones.
+Origin CA Issuer can use an API token that contains the "Zone / SSL and Certificates / Edit" permission, which can be scoped to specific accounts or zones. Both [[https://developers.cloudflare.com/fundamentals/api/get-started/create-token/][user API tokens]] and [[https://developers.cloudflare.com/fundamentals/api/get-started/account-owned-tokens/][Account owned tokens]] are supported.
 
 #+BEGIN_SRC sh :file ./deploy/example/cfapi-token.secret.yaml :results silent file :exports code
 kubectl create secret generic \
@@ -86,7 +86,7 @@ $ kubectl get originissuer.cert-manager.k8s.cloudflare.com prod-issuer -o json |
 #+END_EXAMPLE
 
 **** Origin CA Service Key
-Alternatively, the "Origin CA Key" can be used, also found on the API Tokens page. This key will begin with "v1.0-" and is different from the "Global API Key".
+The [[https://developers.cloudflare.com/fundamentals/api/get-started/ca-keys/][Origin CA Key]] is supported but discouraged in favor of API tokens. This key will begin with "v1.0-" and is different from the legacy "Global API Key".
 
 #+BEGIN_SRC sh :file ./deploy/example/service-key.secret.yaml :results silent file :exports code
 kubectl create secret generic \

--- a/deploy/crds/cert-manager.k8s.cloudflare.com_clusteroriginissuers.yaml
+++ b/deploy/crds/cert-manager.k8s.cloudflare.com_clusteroriginissuers.yaml
@@ -47,7 +47,8 @@ spec:
                   API.
                 properties:
                   serviceKeyRef:
-                    description: ServiceKeyRef authenticates with an API Service Key.
+                    description: ServiceKeyRef authenticates with an API Service Key
+                      (the "Origin CA Key").
                     properties:
                       key:
                         description: Key of the secret to select from. Must be a valid

--- a/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml
+++ b/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml
@@ -47,7 +47,8 @@ spec:
                   API.
                 properties:
                   serviceKeyRef:
-                    description: ServiceKeyRef authenticates with an API Service Key.
+                    description: ServiceKeyRef authenticates with an API Service Key
+                      (the "Origin CA Key").
                     properties:
                       key:
                         description: Key of the secret to select from. Must be a valid

--- a/pkgs/apis/v1/types_originissuer.go
+++ b/pkgs/apis/v1/types_originissuer.go
@@ -82,7 +82,7 @@ type OriginIssuerStatus struct {
 // OriginIssuerAuthentication defines how to authenticate with the Cloudflare API.
 // Only one of `serviceKeyRef` may be specified.
 type OriginIssuerAuthentication struct {
-	// ServiceKeyRef authenticates with an API Service Key.
+	// ServiceKeyRef authenticates with an API Service Key (the "Origin CA Key").
 	// +optional
 	ServiceKeyRef *SecretKeySelector `json:"serviceKeyRef,omitempty"`
 


### PR DESCRIPTION
Update the authentication documentation to discourage Origin CA Keys in favor of scoped API Tokens. This also updates links to Cloudflare Docs rather than deep linking into the Dashboard.