### PR TITLE
feat(cfapi): include origin-ca-issuer version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifeq (${KERNEL},Linux)
 	GOFLAGS ?= -buildmode=pie
 endif
 
-GO_LDFLAGS += -w -s -X main.version=${VERSION}
+GO_LDFLAGS += -w -s -X github.com/cloudflare/origin-ca-issuer/internal/version.Version=${VERSION}
 GOFLAGS += -v
 
 export CGO_ENABLED

--- a/internal/cfapi/cfapi.go
+++ b/internal/cfapi/cfapi.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/cloudflare/origin-ca-issuer/internal/version"
 )
 
 type Interface interface {
@@ -121,7 +123,7 @@ func (c *Client) Sign(ctx context.Context, req *SignRequest) (*SignResponse, err
 		return nil, err
 	}
 
-	r.Header.Add("User-Agent", "github.com/cloudflare/origin-ca-issuer")
+	r.Header.Add("User-Agent", "origin-ca-issuer/"+version.Version)
 
 	if c.serviceKey != nil {
 		r.Header.Add("X-Auth-User-Service-Key", string(c.serviceKey))

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var Version = "0.0.0"

--- a/pkgs/controllers/testdata/database-failure.yaml
+++ b/pkgs/controllers/testdata/database-failure.yaml
@@ -16,7 +16,7 @@ interactions:
           form: {}
           headers:
               User-Agent:
-                  - github.com/cloudflare/origin-ca-issuer
+                  - origin-ca-issuer/0.0.0
               X-Auth-User-Service-Key:
                   - djEuMC0weDAwQkFCMTBD
           url: https://api.cloudflare.com/client/v4/certificates

--- a/pkgs/controllers/testdata/working.yaml
+++ b/pkgs/controllers/testdata/working.yaml
@@ -16,7 +16,7 @@ interactions:
       form: {}
       headers:
         User-Agent:
-          - github.com/cloudflare/origin-ca-issuer
+          - origin-ca-issuer/0.0.0
         X-Auth-User-Service-Key:
           - djEuMC0weDAwQkFCMTBD
       url: https://api.cloudflare.com/client/v4/certificates
@@ -62,7 +62,7 @@ interactions:
       form: {}
       headers:
         User-Agent:
-          - github.com/cloudflare/origin-ca-issuer
+          - origin-ca-issuer/0.0.0
         Authorization:
           - Bearer api-token
       url: https://api.cloudflare.com/client/v4/certificates


### PR DESCRIPTION
The team operating the Origin CA have requested this issuer include version information in the User-Agent to aid in debugging issues on their side and understand the rate at which updates to the issuer have been adopted.

Introduces an internal "version" package where the binary version is set via LDFLAGS. Starting with Go 1.24 this information will be embedded into the binary's module, which can be queried instead.