### PR TITLE
feat(actions): sign images and helm charts

### DIFF
--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -11,6 +11,10 @@ concurrency:
 jobs:
   chart-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,7 +22,13 @@ jobs:
       - uses: azure/setup-helm@v3
       - name: helm package
         run: helm package deploy/charts/origin-ca-issuer
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: helm publish
         run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login -u ${{ github.actor }} --password-stdin ghcr.io
-          helm push origin-ca-issuer-*.tgz oci://ghcr.io/cloudflare/origin-ca-issuer-charts
+          helm push origin-ca-issuer-*.tgz oci://ghcr.io/cloudflare/origin-ca-issuer-charts |& tee helm-push-output.log
+          digest=$(awk -F "[, ]+" '/Digest/{print $NF}' < helm-push-output.log)
+          cosign sign "ghcr.io/cloudflare/origin-ca-issuer-charts/origin-ca-issuer@${digest}"

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -8,6 +8,9 @@ concurrency:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-qemu-action@v3
@@ -16,6 +19,8 @@ jobs:
         with:
           images: cloudflare/origin-ca-issuer
       - uses: docker/setup-buildx-action@v3
+      - uses: sigstore/cosign-installer@v3
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       - uses: docker/login-action@v3
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
@@ -39,6 +44,7 @@ jobs:
             }
           skip-extraction: ${{ steps.cache.outputs.cache-hit }}
       - uses: docker/build-push-action@v5
+        id: docker-push
         with:
           file: ./cmd/controller/Dockerfile
           platforms: linux/amd64, linux/arm64
@@ -48,3 +54,9 @@ jobs:
           push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Sign Images
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        env:
+          TAGS: ${{ steps.docker-meta.outputs.tags }}
+          DIGEST: ${{ steps.docker-push.outputs.digest }}
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes --recursive {}@${DIGEST}


### PR DESCRIPTION
Uses cosign to sign the Docker images and Helm charts with the GitHub
Actions OIDC identity, signifying these artifacts were built in CI.