### PR TITLE
fix: install cosign in Helm publish action

### DIFF
--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           fetch-depth: 0
       - uses: azure/setup-helm@v3
+      - uses: sigstore/cosign-installer@v3
       - name: helm package
         run: helm package deploy/charts/origin-ca-issuer
       - uses: docker/login-action@v3


### PR DESCRIPTION
I've forgotten to install cosign in the GitHub Action for publishing the Helm artifacts causing it to fail.