### PR TITLE
feat: implement leader election

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -22,6 +22,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
+//go:generate go tool controller-gen rbac:roleName=originissuer-control paths=./. output:rbac:artifacts:config=../../deploy/rbac
+
+// +kubebuilder:rbac:groups=cert-manager.io,resources=certificaterequests,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cert-manager.io,resources=certificaterequests/status,verbs=patch
+
+// +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=get;list;watch
+// +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests/status,verbs=patch
+// +kubebuilder:rbac:groups=certificates.k8s.io,resources=signers,verbs=sign,resourceNames=originissuers.cert-manager.k8s.cloudflare.com/*;clusteroriginissuers.cert-manager.k8s.cloudflare.com/*
+
+// +kubebuilder:rbac:groups=cert-manager.k8s.cloudflare.com,resources=originissuers;clusteroriginissuers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=cert-manager.k8s.cloudflare.com,resources=originissuers/status;clusteroriginissuers/status,verbs=patch
+
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+//
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
+
 func main() {
 	fs := pflag.CommandLine
 	o := options.NewControllerOptions()
@@ -62,7 +79,11 @@ func main() {
 	kubeCfg.Burst = o.KubernetesAPIBurst
 
 	mgr, err := manager.New(kubeCfg, manager.Options{
-		Scheme: scheme,
+		Scheme:                        scheme,
+		LeaderElection:                true,
+		LeaderElectionReleaseOnCancel: true,
+		LeaderElectionNamespace:       o.LeaderElectionNamespace,
+		LeaderElectionID:              o.LeaderElectionID,
 	})
 	if err != nil {
 		logger.Error("could not create manager", "error", err)

--- a/cmd/controller/options/options.go
+++ b/cmd/controller/options/options.go
@@ -10,6 +10,8 @@ type ControllerOptions struct {
 	KubernetesAPIQPS         float32
 	KubernetesAPIBurst       int
 	ClusterResourceNamespace string
+	LeaderElectionNamespace  string
+	LeaderElectionID         string
 
 	DisableApprovedCheck bool
 }
@@ -17,12 +19,14 @@ type ControllerOptions struct {
 const (
 	defaultKubernetesAPIQPS   float32 = 20
 	defaultKubernetesAPIBurst int     = 50
+	defaultLeaderElectionID   string  = "origin-ca-issuer"
 )
 
 func NewControllerOptions() *ControllerOptions {
 	return &ControllerOptions{
 		KubernetesAPIQPS:   defaultKubernetesAPIQPS,
 		KubernetesAPIBurst: defaultKubernetesAPIBurst,
+		LeaderElectionID:   defaultLeaderElectionID,
 	}
 }
 
@@ -31,6 +35,8 @@ func (o *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.KubernetesAPIBurst, "kube-api-burst", defaultKubernetesAPIBurst, "Maximium queries-per-second burst of request send to the Kubernetes apiserver.")
 	fs.BoolVar(&o.DisableApprovedCheck, "disable-approved-check", o.DisableApprovedCheck, "Disables waiting for CertificateRequests to have an approved condition before signing.")
 	fs.StringVar(&o.ClusterResourceNamespace, "cluster-resource-namespace", o.ClusterResourceNamespace, "Namespace used for cluster-scoped resources, such as secrets used by ClusterOriginIssuer")
+	fs.StringVar(&o.LeaderElectionNamespace, "leader-election-namespace", o.LeaderElectionNamespace, "Namespace used for leader election leases (defaults to pod's namespace).")
+	fs.StringVar(&o.LeaderElectionID, "leader-election-id", o.LeaderElectionID, "Lease name used for leader election.")
 }
 
 func (o *ControllerOptions) Validate() error {
@@ -44,6 +50,10 @@ func (o *ControllerOptions) Validate() error {
 
 	if o.ClusterResourceNamespace == "" {
 		return fmt.Errorf("invalid value for cluster-resource-namespace: must be set")
+	}
+
+	if o.LeaderElectionID == "" {
+		return fmt.Errorf("invalid value for leader-election-id: must be set")
 	}
 
 	return nil

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -72,3 +72,11 @@ rules:
   - signers
   verbs:
   - sign
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update

--- a/pkgs/controllers/signer.go
+++ b/pkgs/controllers/signer.go
@@ -20,21 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-//go:generate go tool controller-gen rbac:roleName=originissuer-control paths=./. output:rbac:artifacts:config=../../deploy/rbac
-
-// +kubebuilder:rbac:groups=cert-manager.io,resources=certificaterequests,verbs=get;list;watch
-// +kubebuilder:rbac:groups=cert-manager.io,resources=certificaterequests/status,verbs=patch
-
-// +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=get;list;watch
-// +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests/status,verbs=patch
-// +kubebuilder:rbac:groups=certificates.k8s.io,resources=signers,verbs=sign,resourceNames=originissuers.cert-manager.k8s.cloudflare.com/*;clusteroriginissuers.cert-manager.k8s.cloudflare.com/*
-
-// +kubebuilder:rbac:groups=cert-manager.k8s.cloudflare.com,resources=originissuers;clusteroriginissuers,verbs=get;list;watch
-// +kubebuilder:rbac:groups=cert-manager.k8s.cloudflare.com,resources=originissuers/status;clusteroriginissuers/status,verbs=patch
-
-// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
-
 var errNoAuthMethods = errors.New("no authentication methods were configured")
 
 //go:embed certificates


### PR DESCRIPTION
Adds support for leader election, allowing multiple replicas of origin-ca-issuer to run without each racing to request certificates from the Cloudflare API.

Bug: #181