### PR TITLE
fix: log manager setup errors

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -100,7 +100,10 @@ func main() {
 			Timeout: 30 * time.Second,
 		}),
 	}
-	signer.SetupWithManager(ctx, mgr)
+	if err := signer.SetupWithManager(ctx, mgr); err != nil {
+		logger.Error("could not setup controllers with manager", "error", err)
+		os.Exit(1)
+	}
 
 	if err := mgr.Start(ctx); err != nil {
 		logger.Error("could not start manager", "error", err)


### PR DESCRIPTION
It's possible to run the controller without the appropriate permissions or without the origin-ca-issuer or cert-manager CRDs being installed into the cluster. This would result in a partially broken, but still running, controller.

This changeset handles the case where SetupWithManager returns an error by logging and exitting.