### PR TITLE
fix(chart): Use fully qualified image names for CRI-O 1.34+ compatibility

### DIFF
--- a/deploy/charts/origin-ca-issuer/values.yaml
+++ b/deploy/charts/origin-ca-issuer/values.yaml
@@ -17,7 +17,7 @@ global:
 # Value specific to the origin-ca-issuer controller
 controller:
   image:
-    repository: cloudflare/origin-ca-issuer
+    repository: docker.io/cloudflare/origin-ca-issuer
     tag: v0.13.0
     pullPolicy: Always
 

--- a/deploy/manifests/deployment.yaml
+++ b/deploy/manifests/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: originissuer-control
       containers:
         - name: origin-ca-controller
-          image: cloudflare/origin-ca-issuer:v0.13.0
+          image: docker.io/cloudflare/origin-ca-issuer:v0.13.0
           args:
             - --cluster-resource-namespace=$(POD_NAMESPACE)
           env:


### PR DESCRIPTION
## Summary

This PR updates the image names used in the Helm chart templates to use Fully Qualified Image Names (FQIN).

This change is necessary to ensure compatibility with Kubernetes clusters running the CRI-O 1.34 or later container runtime.

## Details

CRI-O 1.34+ has stricter validation and rejects container image pulls that use unqualified (short) names, leading to deployment failures.

The image repository is updated from the short form (`cloudflare/origin-ca-issuer`) to the fully qualified form (`docker.io/cloudflare/origin-ca-issuer`).

## Related Issue

Fixes #188 

## Background

https://github.com/cri-o/cri-o/pull/9401
