### PR TITLE
feat: deprecate serviceKeyRef

### DIFF
--- a/README.org
+++ b/README.org
@@ -87,7 +87,12 @@ $ kubectl get originissuer.cert-manager.k8s.cloudflare.com prod-issuer -o json |
 #+END_EXAMPLE
 
 **** Origin CA Service Key
-The [[https://developers.cloudflare.com/fundamentals/api/get-started/ca-keys/][Origin CA Key]] is supported but discouraged in favor of API tokens. This key will begin with "v1.0-" and is different from the legacy "Global API Key".
+#+BEGIN_QUOTE
+[!WARNING]
+Support for Origin CA Service Keys [[https://developers.cloudflare.com/fundamentals/api/reference/deprecations/#2026-03-19][was deprecated]] on 2026-03-19. Users of Origin CA Issuer should migrate to using API Tokens.
+#+END_QUOTE
+
+The [[https://developers.cloudflare.com/fundamentals/api/get-started/ca-keys/][Origin CA Key]] will begin with "v1.0-" and is different from the legacy "Global API Key".
 
 #+BEGIN_SRC sh :file ./deploy/example/service-key.secret.yaml :results silent file :exports code
 kubectl create secret generic \

--- a/deploy/crds/cert-manager.k8s.cloudflare.com_clusteroriginissuers.yaml
+++ b/deploy/crds/cert-manager.k8s.cloudflare.com_clusteroriginissuers.yaml
@@ -47,8 +47,9 @@ spec:
                   API.
                 properties:
                   serviceKeyRef:
-                    description: ServiceKeyRef authenticates with an API Service Key
-                      (the "Origin CA Key").
+                    description: |-
+                      ServiceKeyRef authenticates with an API Service Key (the "Origin CA Key").
+                      Deprecated: 2026-03-19.
                     properties:
                       key:
                         description: Key of the secret to select from. Must be a valid

--- a/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml
+++ b/deploy/crds/cert-manager.k8s.cloudflare.com_originissuers.yaml
@@ -47,8 +47,9 @@ spec:
                   API.
                 properties:
                   serviceKeyRef:
-                    description: ServiceKeyRef authenticates with an API Service Key
-                      (the "Origin CA Key").
+                    description: |-
+                      ServiceKeyRef authenticates with an API Service Key (the "Origin CA Key").
+                      Deprecated: 2026-03-19.
                     properties:
                       key:
                         description: Key of the secret to select from. Must be a valid

--- a/pkgs/apis/v1/types_originissuer.go
+++ b/pkgs/apis/v1/types_originissuer.go
@@ -78,6 +78,7 @@ type OriginIssuerSpec struct {
 // +kubebuilder:validation:ExactlyOneOf=serviceKeyRef;tokenRef
 type OriginIssuerAuthentication struct {
 	// ServiceKeyRef authenticates with an API Service Key (the "Origin CA Key").
+	// Deprecated: 2026-03-19.
 	// +optional
 	ServiceKeyRef *SecretKeySelector `json:"serviceKeyRef,omitempty"`
 

--- a/pkgs/controllers/signer.go
+++ b/pkgs/controllers/signer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cert-manager/issuer-lib/controllers/signer"
 	"github.com/cloudflare/origin-ca-issuer/internal/cfapi"
 	v1 "github.com/cloudflare/origin-ca-issuer/pkgs/apis/v1"
+	"github.com/go-logr/logr"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,9 +84,15 @@ func (s *Signer) getAuthSecret(ctx context.Context, issuer issuerv1alpha1.Issuer
 }
 
 func (s *Signer) Check(ctx context.Context, issuer issuerv1alpha1.Issuer) error {
+	log := logr.FromContextAsSlogLogger(ctx)
+
 	secret, key, err := s.getAuthSecret(ctx, issuer)
 	if err != nil {
 		return err
+	}
+
+	if issuer.(originIssuer).GetAuth().GetType() == v1.AuthTypeServiceKey {
+		log.WarnContext(ctx, "Issuer uses deprecated serviceKeyRef authentication")
 	}
 
 	_, ok := secret.Data[key]


### PR DESCRIPTION
The deprecation of Origin CA Service Keys was announced in the Cloudflare Developer documentation on 2026-03-19, with removal planned for 2026-09-30.

This changeset adds deprecation warnings in documentation and prints a warning to the log when (Cluster)OriginIssuer uses serviceKeyRef.