### PR TITLE
feat: make Cloudflare API client timeout configurable via CFAPI_TIMEOUT env var

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -77,8 +77,17 @@ func main() {
 
 	collection := provisioners.CollectionWith(nil)
 
+	cfapiTimeout := 30 * time.Second
+	if v := os.Getenv("CFAPI_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfapiTimeout = d
+		} else {
+			log.Error(err, "invalid CFAPI_TIMEOUT, using default", "value", v, "default", cfapiTimeout)
+		}
+	}
+
 	httpClient := &http.Client{
-		Timeout: 30 * time.Second,
+		Timeout: cfapiTimeout,
 	}
 	f := cfapi.FactoryFunc(func(serviceKey []byte) (cfapi.Interface, error) {
 		return cfapi.New(serviceKey, cfapi.WithClient(httpClient)), nil


### PR DESCRIPTION
## Summary

The Cloudflare API client timeout is hardcoded to 30 seconds. When signing certificates with a large number of SANs (107 in our case), the API consistently takes ~43 seconds to respond, causing every sign request to fail with a context deadline exceeded error.

This PR reads a `CFAPI_TIMEOUT` environment variable to allow operators to configure the HTTP client timeout. It defaults to `30s` for full backwards compatibility.

## Changes

- Parse `CFAPI_TIMEOUT` env var as a `time.Duration` at startup
- Fall back to 30s default if unset or unparseable
- Pass the configured duration to the Cloudflare API HTTP client

## Usage

Works out of the box with the existing Helm chart's `controller.extraEnv`:

```yaml
controller:
  extraEnv:
    - name: CFAPI_TIMEOUT
      value: "60s"
```

## Notes

- Fixes https://github.com/cloudflare/origin-ca-issuer/issues/196
- This PR is based on v0.7.0 — happy to rebase onto trunk if maintainers prefer

🤖 Generated with [Claude Code](https://claude.com/claude-code)