### PR TITLE
chore: update GitHub Actions

### DIFF
--- a/.github/workflows/chart-publish.yaml
+++ b/.github/workflows/chart-publish.yaml
@@ -16,14 +16,15 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: azure/setup-helm@v3
-      - uses: sigstore/cosign-installer@v3
+          persist-credentials: false
+      - uses: azure/setup-helm@v5
+      - uses: sigstore/cosign-installer@v4.1.1
       - name: helm package
         run: helm package deploy/charts/origin-ca-issuer
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/charts.yaml
+++ b/.github/workflows/charts.yaml
@@ -8,14 +8,17 @@ concurrency:
 jobs:
   chart-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: azure/setup-helm@v3
-      - uses: actions/setup-python@v4
+          persist-credentials: false
+      - uses: azure/setup-helm@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.11"
+          python-version: "3.13"
           check-latest: true
       - uses: helm/chart-testing-action@v2
       - name: chart-testing (list-changed)

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,48 +12,32 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/metadata-action@v5
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/metadata-action@v6
         id: docker-meta
         with:
           images: cloudflare/origin-ca-issuer
-      - uses: docker/setup-buildx-action@v3
-      - uses: sigstore/cosign-installer@v3
+      - uses: docker/setup-buildx-action@v4
+      - uses: sigstore/cosign-installer@v4.1.1
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - uses: actions/cache@v4
-        id: cache
-        with:
-          path: |
-            go-pkg-mod
-            root-cache-go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - uses: reproducible-containers/buildkit-cache-dance@v3
-        with:
-          cache-map: |
-            {
-              "go-pkg-mod": "/go/pkg/mod",
-              "root-cache-go-build": "/root/.cache/go-build"
-            }
-          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v7
         id: docker-push
         with:
           file: ./cmd/controller/Dockerfile
-          platforms: linux/amd64, linux/arm64
+          platforms: ${{ case(startsWith(github.ref, 'refs/tags/v'), 'linux/amd64,linux/arm64', 'linux/amd64') }}
           sbom: true
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           push: ${{ startsWith(github.ref, 'refs/tags/v') }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
       - name: Sign Images
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         env:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,42 +1,73 @@
-name: Test
+name: Go Checks
 on:
-  - pull_request
-  - push
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  push: {}
+  pull_request: {}
+  schedule:
+    - cron: "10 14 * * *"
+  workflow_dispatch: {}
+permissions:
+  contents: read
 jobs:
-  unit:
+  test:
     runs-on: ubuntu-latest
-    name: "Go ${{ matrix.go }} Test"
+    strategy:
+      fail-fast: true
+      matrix:
+        go:
+          - { go-version: stable }
+          - { go-version: oldstable }
+        deps:
+          - locked
+          - latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go.go-version }}
+      - uses: geomys/sandboxed-step@v1.2.1
+        with:
+          run: |
+            if [ "${{ matrix.deps }}" = "latest" ]; then
+              go get -u -t ./...
+            fi
+            go test ./...
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v6
         with:
           go-version: stable
-      - run: make test
-  lint:
+      - uses: geomys/sandboxed-step@v1.2.1
+        with:
+          run: |
+            source <(go run sigs.k8s.io/controller-runtime/tools/setup-envtest@latest use -p env)
+            make test
+  staticcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v6
         with:
-          go-version: "stable"
-      - uses: dominikh/staticcheck-action@v1
+          persist-credentials: false
+      - uses: actions/setup-go@v6
         with:
-          install-go: false
-  integration:
-    needs:
-      - unit
-      - lint
+          go-version: stable
+      - uses: geomys/sandboxed-step@v1.2.1
+        with:
+          run: go run honnef.co/go/tools/cmd/staticcheck@latest ./...
+  govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v6
         with:
-          go-version: "stable"
-      - name: integration
-        run: |
-          go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-          source <(setup-envtest use -p env)
-          make test
+          persist-credentials: false
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+      - uses: geomys/sandboxed-step@v1.2.1
+        with:
+          run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
GitHub has deprecated Node.js 20 in Action runners, this changeset updates most GitHub Action dependencies to versions using Node.js 24.

This changeset also sandboxes the Go tests, and adds tests against the latest versions of all dependencies, to catch API issues sooner.