### PR TITLE
chore(rbac): include events.k8s.io in clusterrole

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -33,8 +33,9 @@ import (
 // +kubebuilder:rbac:groups=cert-manager.k8s.cloudflare.com,resources=originissuers;clusteroriginissuers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cert-manager.k8s.cloudflare.com,resources=originissuers/status;clusteroriginissuers/status,verbs=patch
 
-// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
+//
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;update
 //
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;create;update
 

--- a/deploy/charts/origin-ca-issuer/Chart.yaml
+++ b/deploy/charts/origin-ca-issuer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: origin-ca-issuer
-version: 0.6.4
+version: 0.6.5
 appVersion: 0.14.0
 description: A Helm chart for origin-ca-issuer
 home: https://github.com/cloudflare/origin-ca-issuer

--- a/deploy/charts/origin-ca-issuer/templates/issuer-clusterrole.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/issuer-clusterrole.yaml
@@ -12,9 +12,6 @@ metadata:
     helm.sh/chart: {{ template "origin-ca-issuer.chart" . }}
 rules:
   - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["create", "patch"]
-  - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["cert-manager.io"]
@@ -42,6 +39,9 @@ rules:
     resources: ["signers"]
     resourceNames: ["clusteroriginissuers.cert-manager.k8s.cloudflare.com/*", "originissuers.cert-manager.k8s.cloudflare.com/*"]
     verbs: ["sign"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["create", "patch", "update"]
 ---
 # permissions to approve all cert-manager.k8s.cloudflare.com requests
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - get
@@ -79,4 +72,12 @@ rules:
   verbs:
   - create
   - get
+  - update
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
   - update


### PR DESCRIPTION
As part of the upgrade to controller-runtime v0.23.1 this issuer switched from the deprecated `manager.GetEventRecorderFor` to the replacement `manager.GetEventRecorder`. This new event recorder uses new Event resources in the events.k8s.io. However the RBAC rules were still defined to use the Event resources from the core group.

Bug: #202
Fixes: 92785e3 ("chore: issuer-lib: v0.9.0 -> v0.10.0")