### PR TITLE
chore(rbac): restore corev1 events

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -33,6 +33,7 @@ import (
 // +kubebuilder:rbac:groups=cert-manager.k8s.cloudflare.com,resources=originissuers;clusteroriginissuers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cert-manager.k8s.cloudflare.com,resources=originissuers/status;clusteroriginissuers/status,verbs=patch
 
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 //
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;update

--- a/deploy/charts/origin-ca-issuer/Chart.yaml
+++ b/deploy/charts/origin-ca-issuer/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 type: application
 name: origin-ca-issuer
-version: 0.6.6
+version: 0.6.7
 appVersion: 0.14.1
 description: A Helm chart for origin-ca-issuer
 home: https://github.com/cloudflare/origin-ca-issuer

--- a/deploy/charts/origin-ca-issuer/templates/issuer-clusterrole.yaml
+++ b/deploy/charts/origin-ca-issuer/templates/issuer-clusterrole.yaml
@@ -12,6 +12,9 @@ metadata:
     helm.sh/chart: {{ template "origin-ca-issuer.chart" . }}
 rules:
   - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["cert-manager.io"]

--- a/deploy/rbac/role.yaml
+++ b/deploy/rbac/role.yaml
@@ -7,6 +7,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get


### PR DESCRIPTION
While controller-runtime has moved to using the new events.k8s.io API, the client-go leader election component still uses the legacy v1 API.

Fixes: 7970e9e8 ("chore(rbac): include events.k8s.io in clusterrole")
Bug: #206